### PR TITLE
Add "add to template" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2021-07-26
+- Added: option to add forgot password link automatically
+
 ## [1.3.1] - 2021-06-02
 
 - changes for contao 4.9+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,163 @@
+GNU Lesser General Public License
+=================================
+
+_Version 3, 29 June 2007_  
+_Copyright © 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;_
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+
+This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+### 0. Additional Definitions
+
+As used herein, “this License” refers to version 3 of the GNU Lesser
+General Public License, and the “GNU GPL” refers to version 3 of the GNU
+General Public License.
+
+“The Library” refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+An “Application” is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+A “Combined Work” is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the “Linked
+Version”.
+
+The “Minimal Corresponding Source” for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+The “Corresponding Application Code” for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+### 1. Exception to Section 3 of the GNU GPL
+
+You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+### 2. Conveying Modified Versions
+
+If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+* **a)** under this License, provided that you make a good faith effort to
+ensure that, in the event an Application does not supply the
+function or data, the facility still operates, and performs
+whatever part of its purpose remains meaningful, or
+
+* **b)** under the GNU GPL, with none of the additional permissions of
+this License applicable to that copy.
+
+### 3. Object Code Incorporating Material from Library Header Files
+
+The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+* **a)** Give prominent notice with each copy of the object code that the
+Library is used in it and that the Library and its use are
+covered by this License.
+* **b)** Accompany the object code with a copy of the GNU GPL and this license
+document.
+
+### 4. Combined Works
+
+You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+* **a)** Give prominent notice with each copy of the Combined Work that
+the Library is used in it and that the Library and its use are
+covered by this License.
+
+* **b)** Accompany the Combined Work with a copy of the GNU GPL and this license
+document.
+
+* **c)** For a Combined Work that displays copyright notices during
+execution, include the copyright notice for the Library among
+these notices, as well as a reference directing the user to the
+copies of the GNU GPL and this license document.
+
+* **d)** Do one of the following:
+    - **0)** Convey the Minimal Corresponding Source under the terms of this
+License, and the Corresponding Application Code in a form
+suitable for, and under terms that permit, the user to
+recombine or relink the Application with a modified version of
+the Linked Version to produce a modified Combined Work, in the
+manner specified by section 6 of the GNU GPL for conveying
+Corresponding Source.
+    - **1)** Use a suitable shared library mechanism for linking with the
+Library.  A suitable mechanism is one that **(a)** uses at run time
+a copy of the Library already present on the user's computer
+system, and **(b)** will operate properly with a modified version
+of the Library that is interface-compatible with the Linked
+Version.
+
+* **e)** Provide Installation Information, but only if you would otherwise
+be required to provide such information under section 6 of the
+GNU GPL, and only to the extent that such information is
+necessary to install and execute a modified version of the
+Combined Work produced by recombining or relinking the
+Application with a modified version of the Linked Version. (If
+you use option **4d0**, the Installation Information must accompany
+the Minimal Corresponding Source and Corresponding Application
+Code. If you use option **4d1**, you must provide the Installation
+Information in the manner specified by section 6 of the GNU GPL
+for conveying Corresponding Source.)
+
+### 5. Combined Libraries
+
+You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+* **a)** Accompany the combined library with a copy of the same work based
+on the Library, uncombined with any other library facilities,
+conveyed under the terms of this License.
+* **b)** Give prominent notice with the combined library that part of it
+is a work based on the Library, and explaining where to find the
+accompanying uncombined form of the same work.
+
+### 6. Revised Versions of the GNU Lesser General Public License
+
+The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License “or any later version”
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -12,23 +12,18 @@ This bundle offers a lost password function for the backend of the Contao CMS.
 ## Installation
 
 1. Install via composer: `composer require heimrichhannot/contao-backend-lost-password-bundle` and update your database.
-1. Copy the template `be_login.html5` from Contao's core to your project's (or project bundle's) templates folder and insert the "lost password"-link by calling `BackendLostPasswortManager->getLostPasswordLink()`. Simply do the following change:
+1. Set the `huh_backend_lost_password.add_to_template` to true if you want the lost password link automatically added to you backend login template.
 
-```
-<!-- ... -->
-<div class="widget">
-    <label for="password"><?= $this->password ?></label>
-    <input type="password" name="password" id="password" class="tl_text" value="" placeholder="<?= $this->password ?>" required>
-</div>
-
-<div class="submit_container cf">
-    <button type="submit" name="login" id="login" class="tl_submit"><?= $this->loginButton ?></button>
-    <a href="<?= $this->route('contao_root') ?>" class="footer_preview"><?= $this->feLink ?> ›</a>
-</div>
-<!-- ... -->
+```yaml
+huh_backend_lost_password:
+    add_to_template: true
 ```
 
-to
+## Customize
+
+### Usage in a custom template
+
+You can insert the lost password link in a custom login template where you want by calling `BackendLostPasswortManager->getLostPasswordLink()`.
 
 ```
 <!-- ... -->
@@ -46,8 +41,6 @@ to
 <!-- ... -->
 ```
 
-## Configuration
-
 ### Adjust the email's text
 
 Simply override the following `$GLOBALS` entries:
@@ -55,4 +48,14 @@ Simply override the following `$GLOBALS` entries:
 ```
 $GLOBALS['TL_LANG']['MSC']['backendLostPassword']['messageSubjectResetPassword']
 $GLOBALS['TL_LANG']['MSC']['backendLostPassword']['messageBodyResetPassword']
+```
+
+## Configuration reference
+
+```yaml
+# Default configuration for extension with alias: "huh_backend_lost_password"
+huh_backend_lost_password:
+
+    # If true, that backend lost password link will be automatically added to the backed login template. Default false. Will be true in the next major version!
+    add_to_template:      false
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
   "require": {
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
-    "heimrichhannot/contao-utils-bundle": "^2.196.0"
+    "heimrichhannot/contao-utils-bundle": "^2.196.0",
+    "symfony/config": "^3.4|^4.4|^5.0",
+    "symfony/dependency-injection": "^3.4|^4.4|^5.0"
   },
   "require-dev": {
     "contao/test-case": "1.1.*",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
-    "heimrichhannot/contao-utils-bundle": "^2.124"
+    "heimrichhannot/contao-utils-bundle": "^2.196.0"
   },
   "require-dev": {
     "contao/test-case": "1.1.*",

--- a/src/ContaoBackendLostPasswordBundle.php
+++ b/src/ContaoBackendLostPasswordBundle.php
@@ -1,9 +1,20 @@
 <?php
 
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace HeimrichHannot\BackendLostPasswordBundle;
 
+use HeimrichHannot\BackendLostPasswordBundle\DependencyInjection\HeimrichHannotBackendLostPasswordExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ContaoBackendLostPasswordBundle extends Bundle
 {
+    public function getContainerExtension()
+    {
+        return new HeimrichHannotBackendLostPasswordExtension();
+    }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\BackendLostPasswordBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('huh_backend_lost_password');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('huh_backend_lost_password');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
+        }
+
+        $rootNode
+            ->children()
+                ->booleanNode('add_to_template')
+                    ->info('If true, that backend lost password link will be automatically added to the backed login template. Default false. Will be true in the next major version!')
+                    ->defaultFalse()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/HeimrichHannotBackendLostPasswordExtension.php
+++ b/src/DependencyInjection/HeimrichHannotBackendLostPasswordExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\BackendLostPasswordBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class HeimrichHannotBackendLostPasswordExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('huh_backend_lost_password', $config);
+    }
+
+    public function getAlias()
+    {
+        return 'huh_backend_lost_password';
+    }
+}

--- a/src/EventListener/Contao/ParseTemplateListener.php
+++ b/src/EventListener/Contao/ParseTemplateListener.php
@@ -13,8 +13,10 @@ use HeimrichHannot\BackendLostPasswordBundle\Manager\BackendLostPasswordManager;
 
 class ParseTemplateListener
 {
-    protected BackendLostPasswordManager $backendLostPasswordManager;
-    protected array $bundleConfig;
+    /** @var BackendLostPasswordManager */
+    protected $backendLostPasswordManager;
+    /** @var array */
+    protected $bundleConfig;
 
     /**
      * ParseTemplateListener constructor.
@@ -28,9 +30,9 @@ class ParseTemplateListener
     public function __invoke(Template $template): void
     {
         if (true === $this->bundleConfig['add_to_template'] && 'be_login' === $template->getName()) {
-            $template->messages = ($template->messages ?? '').$this->backendLostPasswordManager->getLostPasswordLink([
+            $template->messages = $this->backendLostPasswordManager->getLostPasswordLink([
                 'template' => '@ContaoBackendLostPassword/be_lost_password_link_main.html.twig',
-            ]);
+            ]).($template->messages ?? '');
         }
     }
 }

--- a/src/EventListener/Contao/ParseTemplateListener.php
+++ b/src/EventListener/Contao/ParseTemplateListener.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\BackendLostPasswordBundle\EventListener\Contao;
+
+use Contao\Template;
+use HeimrichHannot\BackendLostPasswordBundle\Manager\BackendLostPasswordManager;
+
+class ParseTemplateListener
+{
+    protected BackendLostPasswordManager $backendLostPasswordManager;
+    protected array $bundleConfig;
+
+    /**
+     * ParseTemplateListener constructor.
+     */
+    public function __construct(BackendLostPasswordManager $backendLostPasswordManager, array $bundleConfig)
+    {
+        $this->backendLostPasswordManager = $backendLostPasswordManager;
+        $this->bundleConfig = $bundleConfig;
+    }
+
+    public function __invoke(Template $template): void
+    {
+        if (true === $this->bundleConfig['add_to_template'] && 'be_login' === $template->getName()) {
+            $template->messages = ($template->messages ?? '').$this->backendLostPasswordManager->getLostPasswordLink([
+                'template' => '@ContaoBackendLostPassword/be_lost_password_link_main.html.twig',
+            ]);
+        }
+    }
+}

--- a/src/Manager/BackendLostPasswordManager.php
+++ b/src/Manager/BackendLostPasswordManager.php
@@ -15,7 +15,8 @@ use Twig\Environment as TwigEnvironment;
 
 class BackendLostPasswordManager
 {
-    protected Utils $utils;
+    /** @var Utils */
+    protected $utils;
     /**
      * @var TwigEnvironment
      */

--- a/src/Manager/BackendLostPasswordManager.php
+++ b/src/Manager/BackendLostPasswordManager.php
@@ -1,45 +1,66 @@
 <?php
 
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace HeimrichHannot\BackendLostPasswordBundle\Manager;
 
 use Contao\Environment;
-use HeimrichHannot\UtilsBundle\Container\ContainerUtil;
+use HeimrichHannot\UtilsBundle\Util\Utils;
 use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment as TwigEnvironment;
 
-class BackendLostPasswordManager {
+class BackendLostPasswordManager
+{
+    protected Utils $utils;
     /**
-     * @var \Twig_Environment
+     * @var TwigEnvironment
      */
     private $twig;
     /**
      * @var RouterInterface
      */
     private $router;
-    /**
-     * @var ContainerUtil
-     */
-    private $containerUtil;
 
-    public function __construct(\Twig_Environment $twig, RouterInterface $router, ContainerUtil $containerUtil) {
-
+    public function __construct(TwigEnvironment $twig, RouterInterface $router, Utils $utils)
+    {
         $this->twig = $twig;
         $this->router = $router;
-        $this->containerUtil = $containerUtil;
+        $this->utils = $utils;
     }
 
-    public function getLostPasswordLink()
+    /**
+     * Return the link to the lost password page.
+     *
+     * Options:
+     * - template: (string) Set a custom template. Default '@ContaoBackendLostPassword/link_lost_password.html.twig'
+     *
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function getLostPasswordLink(array $options = []): string
     {
+        $defaults = [
+            'template' => '@ContaoBackendLostPassword/link_lost_password.html.twig',
+        ];
+
+        $options = array_merge($defaults, $options);
+
         $requestRoute = $this->router->getRouteCollection()->get('contao_backend_request_password');
 
         if (version_compare(VERSION, '4.9', '<')) {
-            $requestUrl = Environment::get('url') . ($this->containerUtil->isDev() ? '/app_dev.php' : '') . $requestRoute->getPath();
+            $requestUrl = Environment::get('url').($this->utils->container()->isDev() ? '/app_dev.php' : '').$requestRoute->getPath();
         } else {
-            $requestUrl = Environment::get('url') . $requestRoute->getPath();
+            $requestUrl = Environment::get('url').$requestRoute->getPath();
         }
 
         return $this->twig->render(
-            '@ContaoBackendLostPassword/link_lost_password.html.twig', [
-                'lostPasswordUrl' => $requestUrl
+            $options['template'], [
+                'lostPasswordUrl' => $requestUrl,
             ]
         );
     }

--- a/src/Resources/assets/scss/contao-backend-lost-password.css
+++ b/src/Resources/assets/scss/contao-backend-lost-password.css
@@ -1,4 +1,4 @@
-#main .form.tl_login_form .widget.lost-password {text-align: right;margin: 8px 0;}
+#main form.tl_login_form .widget.lost-password {text-align: right;margin: 8px 0;}
 
 .lost-password.message-section {
     max-width: 350px;

--- a/src/Resources/assets/scss/contao-backend-lost-password.css
+++ b/src/Resources/assets/scss/contao-backend-lost-password.css
@@ -1,1 +1,13 @@
-#main form.tl_login_form .widget.lost-password{text-align:right;margin:8px 0}
+#main .form.tl_login_form .widget.lost-password {text-align: right;margin: 8px 0;}
+
+.lost-password.message-section {
+    max-width: 350px;
+    margin: -30px auto 0;
+    background: #fff;
+    border-radius: 2px;
+}
+
+
+.lost-password.message-section p {
+    padding: 0 45px 45px;
+}

--- a/src/Resources/assets/scss/contao-backend-lost-password.scss
+++ b/src/Resources/assets/scss/contao-backend-lost-password.scss
@@ -1,6 +1,20 @@
 #main {
-  form.tl_login_form .widget.lost-password {
-    text-align: right;
-    margin: 8px 0;
+  form.tl_login_form {
+
+    .widget.lost-password {
+      text-align: right;
+      margin: 8px 0;
+    }
+  }
+}
+
+.lost-password.message-section {
+  max-width: 350px;
+  margin: -30px auto 0;
+  background: #fff;
+  border-radius: 2px;
+
+  p {
+    padding: 0 45px 45px;
   }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,11 @@ services:
   _defaults:
     public: true
     autowire: true
+    bind:
+      $bundleConfig: "%huh_backend_lost_password%"
 
   HeimrichHannot\BackendLostPasswordBundle\Controller\BackendController: ~
   HeimrichHannot\BackendLostPasswordBundle\Manager\BackendLostPasswordManager: ~
+
+  HeimrichHannot\BackendLostPasswordBundle\EventListener\:
+    resource: '../../EventListener/*'

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+use HeimrichHannot\BackendLostPasswordBundle\EventListener\Contao\ParseTemplateListener;
+
 if (\Contao\System::getContainer()->get('huh.utils.container')->isBackend()) {
     $GLOBALS['TL_CSS']['contao-backend-lost-password-bundle'] = 'bundles/contaobackendlostpassword/css/contao-backend-lost-password.css|static';
 }
+
+$GLOBALS['TL_HOOKS']['parseTemplate'][] = [ParseTemplateListener::class, '__invoke'];

--- a/src/Resources/public/css/contao-backend-lost-password.css
+++ b/src/Resources/public/css/contao-backend-lost-password.css
@@ -1,14 +1,1 @@
-#main .form.tl_login_form .widget.lost-password {text-align: right;margin: 8px 0;}
-
-.lost-password.message-section {
-    max-width: 350px;
-    margin: -33px auto 0;
-    background: #fff;
-    border-radius: 2px;
-}
-
-
-.lost-password.message-section p {
-    padding: 0 45px 45px;
-    text-align: right;
-}
+#main form.tl_login_form .widget.lost-password{text-align:right;margin:8px 0}.lost-password.message-section{max-width:350px;margin:-33px auto 0;background:#fff;border-radius:2px}.lost-password.message-section p{padding:0 45px 45px;text-align:right}

--- a/src/Resources/public/css/contao-backend-lost-password.css
+++ b/src/Resources/public/css/contao-backend-lost-password.css
@@ -1,1 +1,14 @@
-#main form.tl_login_form .widget.lost-password{text-align:right;margin:8px 0}
+#main .form.tl_login_form .widget.lost-password {text-align: right;margin: 8px 0;}
+
+.lost-password.message-section {
+    max-width: 350px;
+    margin: -33px auto 0;
+    background: #fff;
+    border-radius: 2px;
+}
+
+
+.lost-password.message-section p {
+    padding: 0 45px 45px;
+    text-align: right;
+}

--- a/src/Resources/views/be_lost_password_link_main.html.twig
+++ b/src/Resources/views/be_lost_password_link_main.html.twig
@@ -1,0 +1,3 @@
+<div class="widget lost-password message-section" style="">
+    <p><a href="{{ lostPasswordUrl }}">{{ 'huh.backend_lost_password.misc.lost_password'|trans }}</a></p>
+</div>


### PR DESCRIPTION
This PR adds an options to automatically add the forgot password link to the template without the need to override the be_login template.

Changelog:
- Added: option to add forgot password link automatically
- Added: template option to BackendLostPasswordManager::getLostPasswordLink()
- Added: license file
- Changed: removed some deprecations